### PR TITLE
Implement `Segment.Contains`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ RFC 9535 JSONPath Tree Queries in Go
 
 The jsonpath package provides [RFC 9535 JSONPath] tree selection in Go.
 
+> [!WARNING]
+> This package is currently under active development. Consider its API
+> unstable until it reaches a level of maturity that deserves a formal version
+> tag.
+
 ## How it Works
 
 Relies on the [github.com/theory/jsonpath] package's [Selector]s for

--- a/segment.go
+++ b/segment.go
@@ -1,6 +1,7 @@
 package jsontree
 
 import (
+	"math"
 	"strings"
 
 	"github.com/theory/jsonpath/spec"
@@ -27,6 +28,194 @@ func Descendant(sel ...spec.Selector) *Segment {
 func (seg *Segment) Append(child ...*Segment) *Segment {
 	seg.children = append(seg.children, child...)
 	return seg
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// Contains returns true if seg contains sel and false if it does not.
+// Accounts for [spec.Index]es in [spec.SliceSelector]s, [spec.SliceSelector]
+// overlap, and compares [*spec.FilterSelector] strings.
+func (seg *Segment) Contains(sel spec.Selector) bool {
+	if len(seg.selectors) == 1 {
+		// A wildcard selector should always be the only selector.
+		if _, ok := seg.selectors[0].(spec.WildcardSelector); ok {
+			return true
+		}
+	}
+
+	// Search for the segment by type.
+	switch sel := sel.(type) {
+	case spec.WildcardSelector:
+		return false
+	case spec.Name:
+		if seg.containsName(sel) {
+			return true
+		}
+	case spec.Index:
+		if seg.containsIndex(sel) {
+			return true
+		}
+	case spec.SliceSelector:
+		if seg.containsSlice(sel) {
+			return true
+		}
+	case *spec.FilterSelector:
+		if seg.containsFilter(sel) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsName returns true if seg contains name.
+func (seg *Segment) containsName(name spec.Name) bool {
+	for _, s := range seg.selectors {
+		if s, ok := s.(spec.Name); ok {
+			if s == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containsIndex returns true if seg contains idx. It evaluates both
+// [spec.Index] values and [spec.SliceSelector]s with positive start and end
+// values and positive steps or a -1 step where end < start. Supports both
+// positive and negative idx values within those constraints.
+func (seg *Segment) containsIndex(idx spec.Index) bool {
+	for _, s := range seg.selectors {
+		switch s := s.(type) {
+		case spec.Index:
+			if s == idx {
+				return true
+			}
+		case spec.SliceSelector:
+			// Negative bounds and backward slice without -1 step depend on
+			// input length, so cannot be determined independently.
+			if s.Start() < 0 || s.End() < 0 || (s.End() < s.Start() && s.Step() != -1) {
+				return false
+			}
+
+			// Set sized based on the slice params and determine the bounds.
+			sel := int(idx)
+			size := max(abs(sel), s.Start(), s.End())
+			if size != math.MaxInt {
+				size++
+			}
+			lower, upper := s.Bounds(size)
+
+			if sel < 0 {
+				// Subtract the index from the upper bound.
+				sel = upper + sel
+			}
+
+			step := s.Step()
+			switch {
+			// step == 0 never selects values.
+			case step > 0 && sel >= lower && sel < upper && ((sel-lower)%step == 0):
+				return true
+			case step == -1 && sel <= upper && sel > lower:
+				// All other negative steps depend on input length.
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// containsSlice returns true if seg contains slice. To qualify, slice's start
+// and end must come between the start and end of a slice in seg, and the step
+// of that slice must be a multiple of slice's step. Or, slice must select a
+// single element that is the same as a [spec.Index] in seg.
+//
+// In theory, all the spec.Index values in seg could account for all the
+// indexes in the slice. But this is good enough for now.
+func (seg *Segment) containsSlice(slice spec.SliceSelector) bool {
+	if slice.Step() == 0 ||
+		slice.Start() == slice.End() ||
+		(slice.Step() > 0 && slice.Start() > slice.End()) ||
+		(slice.Step() < 0 && slice.Start() < slice.End()) {
+		// Never selects anything, so true.
+		return true
+	}
+
+	for _, s := range seg.selectors {
+		switch s := s.(type) {
+		case spec.SliceSelector:
+			if ok := sliceInSlice(slice, s); ok {
+				return true
+			}
+		case spec.Index:
+			idx := int(s)
+			if (slice.Start() == idx && slice.End() == idx+1 && slice.Step() > 0) ||
+				(slice.Start() == idx+1 && slice.End() == idx && slice.Step() < 0) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// sliceInSlice returns true if sub is a subset of or equal to sup. Always
+// returns false if sub.step is not a multiple of sup.step. Accounts for
+// logical subsets where the steps for one slice are positive and the other
+// negative.
+func sliceInSlice(sub, sup spec.SliceSelector) bool {
+	if sub.Step()%sup.Step() != 0 {
+		// Non overlapping if s.Step() is not a multiple of slice.Step()1.
+		return false
+	}
+
+	switch {
+	case sub.Step() > 0 && sup.Step() > 0:
+		// Most common case: is sub between sup start and end?
+		if sub.Start() >= sup.Start() && sub.End() <= sup.End() {
+			return true
+		}
+	case sub.Step() < 0 && sup.Step() < 0:
+		// Both step backward: is sub between sup end and start?
+		if sub.Start() <= sup.Start() && sub.End() >= sup.End() {
+			return true
+		}
+	case sub.Step() <= 1 && sup.Step() > 0:
+		// sub backward vs sup forward: is sub between sup end and start?
+		if sub.Start() < sup.End() && sub.End() >= sup.Start()-1 {
+			return true
+		}
+	case sub.Step() > 0 && sup.Step() < 0:
+		// sub forward vs sup backward: is sub between sup start and end?
+		if sub.End() > sup.Start() && sub.Start()-1 >= sup.End() {
+			return true
+		}
+	}
+	return false
+}
+
+// containsFilter returns true if seg contains filter. Currently relies on
+// string comparison, but could be improved by implementing [sort.Interface]
+// for [spec.LogicalOr] and [spec.LogicalAnd], as well as operand and operator
+// normalization in [spec.ComparisonExpr].
+//
+// [sort.Interface]: https://pkg.go.dev/sort#Interface
+func (seg *Segment) containsFilter(filter *spec.FilterSelector) bool {
+	for _, s := range seg.selectors {
+		if s, ok := s.(*spec.FilterSelector); ok {
+			if s.String() == filter.String() {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // String returns a string representation of seg, including all of its child

--- a/segment_test.go
+++ b/segment_test.go
@@ -1,9 +1,12 @@
 package jsontree
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/theory/jsonpath"
 	"github.com/theory/jsonpath/spec"
 )
 
@@ -208,6 +211,744 @@ func TestWriteNode(t *testing.T) {
 			t.Parallel()
 			n := JSONTree{root: &Segment{children: tc.segs}}
 			a.Equal(tc.str, n.String())
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	simpleExists := mkFilter("$[?@]")
+	diffExists := mkFilter("$[?@.a]")
+
+	for _, tc := range []struct {
+		name string
+		list []spec.Selector
+		sel  spec.Selector
+		exp  bool
+	}{
+		{
+			name: "wildcard_empty",
+			list: []spec.Selector{},
+			sel:  spec.Wildcard,
+			exp:  false,
+		},
+		{
+			name: "wildcard_name",
+			list: []spec.Selector{spec.Name("foo")},
+			sel:  spec.Wildcard,
+			exp:  false,
+		},
+		{
+			name: "wildcard_index",
+			list: []spec.Selector{spec.Index(1)},
+			sel:  spec.Wildcard,
+			exp:  false,
+		},
+		{
+			name: "wildcard_wildcard",
+			list: []spec.Selector{spec.Wildcard},
+			sel:  spec.Wildcard,
+			exp:  true,
+		},
+		{
+			name: "name_empty",
+			list: []spec.Selector{},
+			sel:  spec.Name("foo"),
+			exp:  false,
+		},
+		{
+			name: "name_exists",
+			list: []spec.Selector{spec.Name("foo")},
+			sel:  spec.Name("foo"),
+			exp:  true,
+		},
+		{
+			name: "name_exists_list",
+			list: []spec.Selector{spec.Name("foo"), spec.Name("bar"), spec.Index(0)},
+			sel:  spec.Name("foo"),
+			exp:  true,
+		},
+		{
+			name: "name_not_exists_list",
+			list: []spec.Selector{spec.Name("foo"), spec.Name("bar"), spec.Index(0)},
+			sel:  spec.Name("hello"),
+			exp:  false,
+		},
+		{
+			name: "name_wildcard",
+			list: []spec.Selector{spec.Wildcard},
+			sel:  spec.Name("foo"),
+			exp:  true,
+		},
+		{
+			name: "name_index",
+			list: []spec.Selector{spec.Index(0)},
+			sel:  spec.Name("foo"),
+			exp:  false,
+		},
+		{
+			name: "index_empty",
+			list: []spec.Selector{},
+			sel:  spec.Index(1),
+			exp:  false,
+		},
+		{
+			name: "index_exists",
+			list: []spec.Selector{spec.Index(1)},
+			sel:  spec.Index(1),
+			exp:  true,
+		},
+		{
+			name: "index_wildcard",
+			list: []spec.Selector{spec.Wildcard},
+			sel:  spec.Index(1),
+			exp:  true,
+		},
+		{
+			name: "index_not_exists",
+			list: []spec.Selector{spec.Index(2)},
+			sel:  spec.Index(1),
+			exp:  false,
+		},
+		{
+			name: "index_in_list",
+			list: []spec.Selector{spec.Name("foo"), spec.Index(0), spec.Index(1)},
+			sel:  spec.Index(1),
+			exp:  true,
+		},
+		{
+			name: "index_not_in_list",
+			list: []spec.Selector{spec.Name("foo"), spec.Index(0), spec.Index(1)},
+			sel:  spec.Index(2),
+			exp:  false,
+		},
+		{
+			name: "index_in_default_slice",
+			list: []spec.Selector{spec.Slice()},
+			sel:  spec.Index(2),
+			exp:  true,
+		},
+		{
+			name: "index_in_explicit_slice",
+			list: []spec.Selector{spec.Slice(1, 4)},
+			sel:  spec.Index(2),
+			exp:  true,
+		},
+		{
+			name: "index_in_explicit_slice_step",
+			list: []spec.Selector{spec.Slice(1, 4, 2)},
+			sel:  spec.Index(3),
+			exp:  true,
+		},
+		{
+			name: "index_not_in_explicit_slice_step",
+			list: []spec.Selector{spec.Slice(1, 4, 2)},
+			sel:  spec.Index(2),
+			exp:  false,
+		},
+		{
+			name: "index_not_in_backwards_slice",
+			list: []spec.Selector{spec.Slice(4, 1)},
+			sel:  spec.Index(2),
+			exp:  false,
+		},
+		{
+			name: "index_start_of_explicit_slice",
+			list: []spec.Selector{spec.Slice(1, 4)},
+			sel:  spec.Index(1),
+			exp:  true,
+		},
+		{
+			name: "index_end_of_explicit_slice",
+			list: []spec.Selector{spec.Slice(1, 4)},
+			sel:  spec.Index(3),
+			exp:  true,
+		},
+		{
+			name: "index_gt_explicit_slice",
+			list: []spec.Selector{spec.Slice(1, 4)},
+			sel:  spec.Index(5),
+			exp:  false,
+		},
+		{
+			name: "index_lt_explicit_slice",
+			list: []spec.Selector{spec.Slice(1, 4)},
+			sel:  spec.Index(0),
+			exp:  false,
+		},
+		{
+			name: "index_not_in_neg_slice",
+			list: []spec.Selector{spec.Slice(-4, -1)},
+			sel:  spec.Index(2),
+			exp:  false,
+		},
+		{
+			name: "neg_index_in_default",
+			list: []spec.Selector{spec.Slice()},
+			sel:  spec.Index(-5),
+			exp:  true,
+		},
+		{
+			name: "neg_one_in_default",
+			list: []spec.Selector{spec.Slice()},
+			sel:  spec.Index(-1),
+			exp:  true,
+		},
+		{
+			name: "neg_one_in_explicit",
+			list: []spec.Selector{spec.Slice(0, 5)},
+			sel:  spec.Index(-1),
+			exp:  true,
+		},
+		{
+			name: "neg_just_in_explicit",
+			list: []spec.Selector{spec.Slice(0, 2)},
+			sel:  spec.Index(-2),
+			exp:  true,
+		},
+		{
+			name: "neg_not_in_explicit",
+			list: []spec.Selector{spec.Slice(0, 2)},
+			sel:  spec.Index(-3),
+			exp:  false,
+		},
+		{
+			name: "in_neg_step",
+			list: []spec.Selector{spec.Slice(5, 2, -1)},
+			sel:  spec.Index(3),
+			exp:  true,
+		},
+		{
+			name: "not_in_neg_two_step",
+			list: []spec.Selector{spec.Slice(6, 2, -2)},
+			sel:  spec.Index(4),
+			exp:  false,
+		},
+		{
+			name: "not_in_neg_three_step",
+			list: []spec.Selector{spec.Slice(6, 1, -3)},
+			sel:  spec.Index(2),
+			exp:  false,
+		},
+		{
+			name: "slice_empty",
+			list: []spec.Selector{},
+			sel:  spec.Slice(),
+			exp:  false,
+		},
+		{
+			name: "slice_step_0",
+			list: []spec.Selector{},
+			sel:  spec.Slice(1, 3, 0),
+			exp:  true,
+		},
+		{
+			name: "slice_start_stop_equal",
+			list: []spec.Selector{},
+			sel:  spec.Slice(3, 3),
+			exp:  true,
+		},
+		{
+			name: "same_slice",
+			list: []spec.Selector{spec.Slice(1, 3)},
+			sel:  spec.Slice(1, 3),
+			exp:  true,
+		},
+		{
+			name: "within_slice_start",
+			list: []spec.Selector{spec.Slice(1, 3)},
+			sel:  spec.Slice(2, 3),
+			exp:  true,
+		},
+		{
+			name: "before_start",
+			list: []spec.Selector{spec.Slice(1, 3)},
+			sel:  spec.Slice(0, 2),
+			exp:  false,
+		},
+		{
+			name: "after_end",
+			list: []spec.Selector{spec.Slice(1, 3)},
+			sel:  spec.Slice(1, 4),
+			exp:  false,
+		},
+		{
+			name: "no_selectors",
+			list: []spec.Selector{},
+			sel:  simpleExists,
+			exp:  false,
+		},
+		{
+			name: "has_filter",
+			list: []spec.Selector{simpleExists},
+			sel:  simpleExists,
+			exp:  true,
+		},
+		{
+			name: "not_has_filter",
+			list: []spec.Selector{simpleExists},
+			sel:  diffExists,
+			exp:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{selectors: tc.list}
+			a.Equal(tc.exp, seg.Contains(tc.sel))
+		})
+	}
+}
+
+func TestContainsIndex(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name  string
+		slice spec.SliceSelector
+		idx   int
+		exp   bool
+	}{
+		{
+			name:  "in_slice_end",
+			slice: spec.Slice(nil, 6),
+			idx:   5,
+			exp:   true,
+		},
+		{
+			name:  "not_in_slice_end",
+			slice: spec.Slice(nil, 6),
+			idx:   6,
+			exp:   false,
+		},
+		{
+			name:  "in_bounded",
+			slice: spec.Slice(2, 6),
+			idx:   5,
+			exp:   true,
+		},
+		{
+			name:  "not_in_bounded",
+			slice: spec.Slice(2, 6),
+			idx:   6,
+			exp:   false,
+		},
+		{
+			name:  "in_bounded_step_two",
+			slice: spec.Slice(2, 6, 2),
+			idx:   4,
+			exp:   true,
+		},
+		{
+			name:  "not_in_bounded_step_two",
+			slice: spec.Slice(2, 6, 2),
+			idx:   3,
+			exp:   false,
+		},
+		{
+			name:  "index_not_in_backwards_slice",
+			slice: spec.Slice(4, 1),
+			idx:   2,
+			exp:   false,
+		},
+		{
+			name:  "at_slice_start",
+			slice: spec.Slice(1, 4),
+			idx:   1,
+			exp:   true,
+		},
+		{
+			name:  "at_slice_default_start",
+			slice: spec.Slice(nil, 4),
+			idx:   0,
+			exp:   true,
+		},
+		{
+			name:  "before_slice_start",
+			slice: spec.Slice(2, 4),
+			idx:   1,
+			exp:   false,
+		},
+		{
+			name:  "neg_start",
+			slice: spec.Slice(-4, 20),
+			idx:   2,
+			exp:   false,
+		},
+		{
+			name:  "neg_end",
+			slice: spec.Slice(0, -1),
+			idx:   2,
+			exp:   false,
+		},
+		{
+			name:  "both_neg",
+			slice: spec.Slice(-4, -1),
+			idx:   0,
+			exp:   false,
+		},
+		{
+			name:  "end_lt_start",
+			slice: spec.Slice(12, 0),
+			idx:   5,
+			exp:   false,
+		},
+		{
+			name:  "in_neg_one_step",
+			slice: spec.Slice(5, 2, -1),
+			idx:   3,
+			exp:   true,
+		},
+		{
+			name:  "not_neg_one_step",
+			slice: spec.Slice(5, 2, -1),
+			idx:   1,
+			exp:   false,
+		},
+		{
+			name:  "exclude_end_neg_one_step",
+			slice: spec.Slice(5, 2, -1),
+			idx:   2,
+			exp:   false,
+		},
+		{
+			name:  "in_neg_one_step_start",
+			slice: spec.Slice(5, 2, -1),
+			idx:   5,
+			exp:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{selectors: []spec.Selector{tc.slice}}
+			a.Equal(tc.exp, seg.containsIndex(spec.Index(tc.idx)))
+
+			// Test with actual data.
+			size := 1 + max(abs(tc.idx), abs(tc.slice.Start()), abs(tc.slice.End()))
+			input := make([]any, size)
+			switch {
+			case tc.idx >= 0:
+				input[tc.idx] = true
+			case tc.idx < 0:
+				input[len(input)+tc.idx] = true
+			}
+			res := tc.slice.Select(input, nil)
+			a.Equal(tc.exp, slices.Contains(res, true))
+		})
+	}
+}
+
+func TestContainsFilter(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	simpleExists := mkFilter("$[?@]")
+	diffExists := mkFilter("$[?@.a]")
+
+	for _, tc := range []struct {
+		name   string
+		list   []spec.Selector
+		filter *spec.FilterSelector
+		exp    bool
+	}{
+		{
+			name:   "no_selectors",
+			list:   []spec.Selector{},
+			filter: simpleExists,
+			exp:    false,
+		},
+		{
+			name:   "has_filter",
+			list:   []spec.Selector{simpleExists},
+			filter: simpleExists,
+			exp:    true,
+		},
+		{
+			name:   "not_has_filter",
+			list:   []spec.Selector{simpleExists},
+			filter: diffExists,
+			exp:    false,
+		},
+		{
+			name:   "same_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x > @.y]")},
+			filter: mkFilter("$[?@.x > @.y]"),
+			exp:    true,
+		},
+		{
+			name:   "diff_cmp_operands",
+			list:   []spec.Selector{mkFilter("$[?@.a > @.y]")},
+			filter: mkFilter("$[?@.x > @.y]"),
+			exp:    false,
+		},
+		{
+			name:   "diff_and_operands",
+			list:   []spec.Selector{mkFilter("$[?@.a && @.y]")},
+			filter: mkFilter("$[?@.x && @.y]"),
+			exp:    false,
+		},
+		{
+			name:   "diff_or_operands",
+			list:   []spec.Selector{mkFilter("$[?@.a || @.y]")},
+			filter: mkFilter("$[?@.x || @.y]"),
+			exp:    false,
+		},
+		// These examples could be equivalent if spec.ComparisonExpr
+		// normalized its expressions for deterministic order.
+		{
+			name:   "reversed_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x > @.y]")},
+			filter: mkFilter("$[?@.y > @.x]"),
+			exp:    false,
+		},
+		{
+			name:   "reversed_eq_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x == @.y]")},
+			filter: mkFilter("$[?@.y == @.x]"),
+			exp:    false,
+		},
+		{
+			name:   "reversed_ne_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x != @.y]")},
+			filter: mkFilter("$[?@.y != @.x]"),
+			exp:    false,
+		},
+		// These examples could be equal if spec.LogicalOr and spec.LogicalAnd
+		// normalized adopted https://pkg.go.dev/sort#Interface.
+		{
+			name:   "reversed_or_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x || @.y]")},
+			filter: mkFilter("$[?@.y || @.x]"),
+			exp:    false,
+		},
+		{
+			name:   "reversed_and_operands",
+			list:   []spec.Selector{mkFilter("$[?@.x && @.y]")},
+			filter: mkFilter("$[?@.y && @.x]"),
+			exp:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{selectors: tc.list}
+			a.Equal(tc.exp, seg.containsFilter(tc.filter))
+		})
+	}
+}
+
+func mkFilter(f string) *spec.FilterSelector {
+	p := jsonpath.MustParse(f)
+	filter := p.Query().Segments()[0].Selectors()[0]
+	if f, ok := filter.(*spec.FilterSelector); ok {
+		return f
+	}
+	panic(fmt.Sprintf("Expected *spec.FilterSelector, got %T", filter))
+}
+
+func TestContainsSlice(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name  string
+		list  []spec.Selector
+		slice spec.SliceSelector
+		exp   bool
+	}{
+		{
+			name:  "no_selectors",
+			list:  []spec.Selector{},
+			slice: spec.Slice(),
+			exp:   false,
+		},
+		{
+			name:  "step_0",
+			list:  []spec.Selector{},
+			slice: spec.Slice(1, 3, 0),
+			exp:   true,
+		},
+		{
+			name:  "start_stop_equal",
+			list:  []spec.Selector{},
+			slice: spec.Slice(3, 3),
+			exp:   true,
+		},
+		{
+			name:  "same_slice",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			slice: spec.Slice(1, 3),
+			exp:   true,
+		},
+		{
+			name:  "within_start",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			slice: spec.Slice(2, 3),
+			exp:   true,
+		},
+		{
+			name:  "within_end",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			slice: spec.Slice(1, 2),
+			exp:   true,
+		},
+		{
+			name:  "before_start",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			slice: spec.Slice(0, 2),
+			exp:   false,
+		},
+		{
+			name:  "after_end",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			slice: spec.Slice(1, 4),
+			exp:   false,
+		},
+		{
+			name:  "multiple_of_step",
+			list:  []spec.Selector{spec.Slice(1, 3, 2)},
+			slice: spec.Slice(1, 3, 4),
+			exp:   true,
+		},
+		{
+			name:  "out_of_step",
+			list:  []spec.Selector{spec.Slice(1, 3, 2)},
+			slice: spec.Slice(1, 3, 3),
+			exp:   false,
+		},
+		{
+			name:  "over_step",
+			list:  []spec.Selector{spec.Slice(1, 3, 4)},
+			slice: spec.Slice(1, 3, 2),
+			exp:   false,
+		},
+
+		{
+			name:  "same_backward_slice",
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(3, 1, -1),
+			exp:   true,
+		},
+		{
+			name:  "within_start_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(3, 2, -1),
+			exp:   true,
+		},
+		{
+			name:  "within_end_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(2, 1, -1),
+			exp:   true,
+		},
+		{
+			name:  "after_end_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(2, 0, -1),
+			exp:   false,
+		},
+		{
+			name:  "before_start_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(4, 1, -1),
+			exp:   false,
+		},
+		{
+			name:  "multiple_of_backward_step",
+			list:  []spec.Selector{spec.Slice(3, 1, -2)},
+			slice: spec.Slice(3, 1, -4),
+			exp:   true,
+		},
+		{
+			name:  "out_of_step_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -2)},
+			slice: spec.Slice(3, 1, -3),
+			exp:   false,
+		},
+		{
+			name:  "over_step_backward",
+			list:  []spec.Selector{spec.Slice(3, 1, -4)},
+			slice: spec.Slice(3, 1, -2),
+			exp:   false,
+		},
+		{
+			name: "opposite_step_not_in_range",
+			// $[1:3:1] != $[3:1:-1]
+			list:  []spec.Selector{spec.Slice(3, 1, -1)},
+			slice: spec.Slice(1, 3, 1),
+			exp:   false,
+		},
+		{
+			// $[2:0:-1] == $[1:3:1]
+			name:  "opposites",
+			list:  []spec.Selector{spec.Slice(1, 3, 1)},
+			slice: spec.Slice(2, 0, -1),
+			exp:   true,
+		},
+		{
+			// $[1:3:1] == $[2:0:-1]
+			name:  "inverted_opposites",
+			list:  []spec.Selector{spec.Slice(2, 0, -1)},
+			slice: spec.Slice(1, 3, 1),
+			exp:   true,
+		},
+		{
+			// $[2:0:-2] mod within $[1:3:1]
+			name:  "opposite_mod_step",
+			list:  []spec.Selector{spec.Slice(1, 3, 1)},
+			slice: spec.Slice(2, 0, -2),
+			exp:   true,
+		},
+		{
+			// $[1:3:1] not mod within $[2:0:-2]
+			name:  "opposite_not_mod_step",
+			list:  []spec.Selector{spec.Slice(2, 0, -2)},
+			slice: spec.Slice(1, 3, 1),
+			exp:   false,
+		},
+		{
+			// $[2:0:-1] within $[1:5:1]
+			name:  "within_opposite",
+			list:  []spec.Selector{spec.Slice(1, 5, 1)},
+			slice: spec.Slice(2, 0, -1),
+			exp:   true,
+		},
+		{
+			name:  "equals_index",
+			list:  []spec.Selector{spec.Index(3)},
+			slice: spec.Slice(3, 4),
+			exp:   true,
+		},
+		{
+			name:  "equals_index_inverted",
+			list:  []spec.Selector{spec.Index(3)},
+			slice: spec.Slice(4, 3, -1),
+			exp:   true,
+		},
+		{
+			name:  "not_equals_index",
+			list:  []spec.Selector{spec.Index(4)},
+			slice: spec.Slice(3, 4),
+			exp:   false,
+		},
+		{
+			name:  "not_equals_index_inverted",
+			list:  []spec.Selector{spec.Index(4)},
+			slice: spec.Slice(4, 3, -1),
+			exp:   false,
+		},
+		{
+			// XXX Compare all indexes to slice range?
+			name:  "equals_all_indexes",
+			list:  []spec.Selector{spec.Index(3), spec.Index(4)},
+			slice: spec.Slice(3, 5),
+			exp:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{selectors: tc.list}
+			a.Equal(tc.exp, seg.containsSlice(tc.slice))
 		})
 	}
 }


### PR DESCRIPTION
This method returns true if a segment contains a selector. It supports direct comparison of Name, Index, and stringified Filter selectors, but also makes an effort to return true when a Slice selector contains an Index or is a subset of another Slice.

Also: Add a stability notice to the README.