### PR TITLE
Implement path merging

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/theory/jsonpath/spec"
+	"github.com/theory/jsonpath"
 	"github.com/theory/jsontree"
 )
 
@@ -55,15 +55,10 @@ func Example() {
 
 	// Create a JSONTree query to fetch
 	tree := jsontree.New(
-		// Select only "profile" from the root.
-		jsontree.Child(spec.Name("profile")).Append(
-			// Select any field under "profile" named "last".
-			jsontree.Descendant(spec.Name("last")),
-			// Select the "primary" field from any object under "contacts".
-			jsontree.Descendant(spec.Name("contacts")).Append(
-				jsontree.Child(spec.Name("primary")),
-			),
-		),
+		// Select any field under "profile" named "last".
+		jsonpath.MustParse("$.profile..last"),
+		// Select the "primary" field from any object under "contacts".
+		jsonpath.MustParse("$.profile..contacts.primary"),
 	)
 
 	// Select a new object from the original.

--- a/segment_test.go
+++ b/segment_test.go
@@ -209,71 +209,94 @@ func TestWriteNode(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			n := JSONTree{root: &Segment{children: tc.segs}}
+			n := Tree{root: &Segment{children: tc.segs}}
 			a.Equal(tc.str, n.String())
 		})
 	}
 }
 
-func TestContains(t *testing.T) {
+func TestIsWildcard(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		seg  *Segment
+		exp  bool
+	}{
+		{"empty", &Segment{}, false},
+		{"name", &Segment{selectors: []spec.Selector{spec.Name("x")}}, false},
+		{"index", &Segment{selectors: []spec.Selector{spec.Index(0)}}, false},
+		{"slice", &Segment{selectors: []spec.Selector{spec.Slice()}}, false},
+		{"filter", &Segment{selectors: []spec.Selector{mkFilter("$[?@]")}}, false},
+		{"wildcard", &Segment{selectors: []spec.Selector{spec.Wildcard}}, true},
+		{"multiples", &Segment{selectors: []spec.Selector{spec.Wildcard, spec.Index(0)}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a.Equal(tc.exp, tc.seg.isWildcard())
+		})
+	}
+}
+
+func TestHasSelector(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
 	simpleExists := mkFilter("$[?@]")
 	diffExists := mkFilter("$[?@.a]")
 
 	for _, tc := range []struct {
-		name string
-		list []spec.Selector
-		sel  spec.Selector
-		exp  bool
+		name  string
+		list  []spec.Selector
+		sel   spec.Selector
+		exp   bool
+		exact bool
 	}{
 		{
 			name: "wildcard_empty",
 			list: []spec.Selector{},
 			sel:  spec.Wildcard,
-			exp:  false,
 		},
 		{
 			name: "wildcard_name",
 			list: []spec.Selector{spec.Name("foo")},
 			sel:  spec.Wildcard,
-			exp:  false,
 		},
 		{
 			name: "wildcard_index",
 			list: []spec.Selector{spec.Index(1)},
 			sel:  spec.Wildcard,
-			exp:  false,
 		},
 		{
-			name: "wildcard_wildcard",
-			list: []spec.Selector{spec.Wildcard},
-			sel:  spec.Wildcard,
-			exp:  true,
+			name:  "wildcard_wildcard",
+			list:  []spec.Selector{spec.Wildcard},
+			sel:   spec.Wildcard,
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "name_empty",
 			list: []spec.Selector{},
 			sel:  spec.Name("foo"),
-			exp:  false,
 		},
 		{
-			name: "name_exists",
-			list: []spec.Selector{spec.Name("foo")},
-			sel:  spec.Name("foo"),
-			exp:  true,
+			name:  "name_exists",
+			list:  []spec.Selector{spec.Name("foo")},
+			sel:   spec.Name("foo"),
+			exp:   true,
+			exact: true,
 		},
 		{
-			name: "name_exists_list",
-			list: []spec.Selector{spec.Name("foo"), spec.Name("bar"), spec.Index(0)},
-			sel:  spec.Name("foo"),
-			exp:  true,
+			name:  "name_exists_list",
+			list:  []spec.Selector{spec.Name("foo"), spec.Name("bar"), spec.Index(0)},
+			sel:   spec.Name("foo"),
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "name_not_exists_list",
 			list: []spec.Selector{spec.Name("foo"), spec.Name("bar"), spec.Index(0)},
 			sel:  spec.Name("hello"),
-			exp:  false,
 		},
 		{
 			name: "name_wildcard",
@@ -285,19 +308,18 @@ func TestContains(t *testing.T) {
 			name: "name_index",
 			list: []spec.Selector{spec.Index(0)},
 			sel:  spec.Name("foo"),
-			exp:  false,
 		},
 		{
 			name: "index_empty",
 			list: []spec.Selector{},
 			sel:  spec.Index(1),
-			exp:  false,
 		},
 		{
-			name: "index_exists",
-			list: []spec.Selector{spec.Index(1)},
-			sel:  spec.Index(1),
-			exp:  true,
+			name:  "index_exists",
+			list:  []spec.Selector{spec.Index(1)},
+			sel:   spec.Index(1),
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "index_wildcard",
@@ -309,19 +331,18 @@ func TestContains(t *testing.T) {
 			name: "index_not_exists",
 			list: []spec.Selector{spec.Index(2)},
 			sel:  spec.Index(1),
-			exp:  false,
 		},
 		{
-			name: "index_in_list",
-			list: []spec.Selector{spec.Name("foo"), spec.Index(0), spec.Index(1)},
-			sel:  spec.Index(1),
-			exp:  true,
+			name:  "index_in_list",
+			list:  []spec.Selector{spec.Name("foo"), spec.Index(0), spec.Index(1)},
+			sel:   spec.Index(1),
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "index_not_in_list",
 			list: []spec.Selector{spec.Name("foo"), spec.Index(0), spec.Index(1)},
 			sel:  spec.Index(2),
-			exp:  false,
 		},
 		{
 			name: "index_in_default_slice",
@@ -345,13 +366,11 @@ func TestContains(t *testing.T) {
 			name: "index_not_in_explicit_slice_step",
 			list: []spec.Selector{spec.Slice(1, 4, 2)},
 			sel:  spec.Index(2),
-			exp:  false,
 		},
 		{
 			name: "index_not_in_backwards_slice",
 			list: []spec.Selector{spec.Slice(4, 1)},
 			sel:  spec.Index(2),
-			exp:  false,
 		},
 		{
 			name: "index_start_of_explicit_slice",
@@ -369,19 +388,16 @@ func TestContains(t *testing.T) {
 			name: "index_gt_explicit_slice",
 			list: []spec.Selector{spec.Slice(1, 4)},
 			sel:  spec.Index(5),
-			exp:  false,
 		},
 		{
 			name: "index_lt_explicit_slice",
 			list: []spec.Selector{spec.Slice(1, 4)},
 			sel:  spec.Index(0),
-			exp:  false,
 		},
 		{
 			name: "index_not_in_neg_slice",
 			list: []spec.Selector{spec.Slice(-4, -1)},
 			sel:  spec.Index(2),
-			exp:  false,
 		},
 		{
 			name: "neg_index_in_default",
@@ -411,7 +427,6 @@ func TestContains(t *testing.T) {
 			name: "neg_not_in_explicit",
 			list: []spec.Selector{spec.Slice(0, 2)},
 			sel:  spec.Index(-3),
-			exp:  false,
 		},
 		{
 			name: "in_neg_step",
@@ -423,19 +438,16 @@ func TestContains(t *testing.T) {
 			name: "not_in_neg_two_step",
 			list: []spec.Selector{spec.Slice(6, 2, -2)},
 			sel:  spec.Index(4),
-			exp:  false,
 		},
 		{
 			name: "not_in_neg_three_step",
 			list: []spec.Selector{spec.Slice(6, 1, -3)},
 			sel:  spec.Index(2),
-			exp:  false,
 		},
 		{
 			name: "slice_empty",
 			list: []spec.Selector{},
 			sel:  spec.Slice(),
-			exp:  false,
 		},
 		{
 			name: "slice_step_0",
@@ -450,10 +462,11 @@ func TestContains(t *testing.T) {
 			exp:  true,
 		},
 		{
-			name: "same_slice",
-			list: []spec.Selector{spec.Slice(1, 3)},
-			sel:  spec.Slice(1, 3),
-			exp:  true,
+			name:  "same_slice",
+			list:  []spec.Selector{spec.Slice(1, 3)},
+			sel:   spec.Slice(1, 3),
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "within_slice_start",
@@ -465,37 +478,99 @@ func TestContains(t *testing.T) {
 			name: "before_start",
 			list: []spec.Selector{spec.Slice(1, 3)},
 			sel:  spec.Slice(0, 2),
-			exp:  false,
 		},
 		{
 			name: "after_end",
 			list: []spec.Selector{spec.Slice(1, 3)},
 			sel:  spec.Slice(1, 4),
-			exp:  false,
 		},
 		{
 			name: "no_selectors",
 			list: []spec.Selector{},
 			sel:  simpleExists,
-			exp:  false,
 		},
 		{
-			name: "has_filter",
-			list: []spec.Selector{simpleExists},
-			sel:  simpleExists,
-			exp:  true,
+			name:  "has_filter",
+			list:  []spec.Selector{simpleExists},
+			sel:   simpleExists,
+			exp:   true,
+			exact: true,
 		},
 		{
 			name: "not_has_filter",
 			list: []spec.Selector{simpleExists},
 			sel:  diffExists,
-			exp:  false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			a.Equal(tc.exp, selectorsContain(tc.list, tc.sel))
 			seg := &Segment{selectors: tc.list}
-			a.Equal(tc.exp, seg.Contains(tc.sel))
+			a.Equal(tc.exp, seg.hasSelector(tc.sel))
+			a.Equal(tc.exact, seg.hasExactSelector(tc.sel))
+		})
+	}
+}
+
+func TestHasSelectors(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	// simpleExists := mkFilter("$[?@]")
+	// diffExists := mkFilter("$[?@.a]")
+
+	for _, tc := range []struct {
+		name      string
+		seg       *Segment
+		selectors []spec.Selector
+		exp       bool
+		same      bool
+		exact     bool
+	}{
+		{
+			name:      "empty",
+			seg:       Child(),
+			selectors: []spec.Selector{},
+			exp:       true,
+			same:      true,
+			exact:     true,
+		},
+		{
+			name:      "a_name",
+			seg:       Child(spec.Name("x")),
+			selectors: []spec.Selector{spec.Name("x")},
+			exp:       true,
+			same:      true,
+			exact:     true,
+		},
+		{
+			name:      "diff_name",
+			seg:       Child(spec.Name("x")),
+			selectors: []spec.Selector{spec.Name("y")},
+		},
+		{
+			name:      "diff_length",
+			seg:       Child(spec.Name("x")),
+			selectors: []spec.Selector{spec.Name("x"), spec.Name("y")},
+		},
+		{
+			name:      "diff_length_has_ok",
+			seg:       Child(spec.Name("x"), spec.Name("y")),
+			selectors: []spec.Selector{spec.Name("x")},
+			exp:       true,
+		},
+		{
+			name:      "same_not_exact",
+			seg:       Child(spec.Name("x"), spec.Slice(0)),
+			selectors: []spec.Selector{spec.Name("x"), spec.Index(0)},
+			exp:       true,
+			same:      true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a.Equal(tc.exp, tc.seg.hasSelectors(tc.selectors))
+			a.Equal(tc.same, tc.seg.hasSameSelectors(tc.selectors))
+			a.Equal(tc.exact, tc.seg.hasExactSelectors(tc.selectors))
 		})
 	}
 }
@@ -621,8 +696,7 @@ func TestContainsIndex(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			seg := &Segment{selectors: []spec.Selector{tc.slice}}
-			a.Equal(tc.exp, seg.containsIndex(spec.Index(tc.idx)))
+			a.Equal(tc.exp, containsIndex([]spec.Selector{tc.slice}, spec.Index(tc.idx)))
 
 			// Test with actual data.
 			size := 1 + max(abs(tc.idx), abs(tc.slice.Start()), abs(tc.slice.End()))
@@ -731,8 +805,7 @@ func TestContainsFilter(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			seg := &Segment{selectors: tc.list}
-			a.Equal(tc.exp, seg.containsFilter(tc.filter))
+			a.Equal(tc.exp, containsFilter(tc.list, tc.filter))
 		})
 	}
 }
@@ -947,8 +1020,694 @@ func TestContainsSlice(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			seg := &Segment{selectors: tc.list}
-			a.Equal(tc.exp, seg.containsSlice(tc.slice))
+			a.Equal(tc.exp, containsSlice(tc.list, tc.slice))
+		})
+	}
+}
+
+func TestIsBranch(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name   string
+		seg    *Segment
+		branch []*spec.Segment
+		exp    bool
+	}{
+		{
+			name:   "empty",
+			seg:    &Segment{},
+			branch: []*spec.Segment{},
+			exp:    true,
+		},
+		{
+			name:   "empty_is_not_name",
+			seg:    &Segment{},
+			branch: []*spec.Segment{spec.Child(spec.Name("x"))},
+			exp:    false,
+		},
+		{
+			name:   "eq_name",
+			seg:    &Segment{children: []*Segment{Child(spec.Name("x"))}},
+			branch: []*spec.Segment{spec.Child(spec.Name("x"))},
+			exp:    true,
+		},
+		{
+			name:   "ne_name",
+			seg:    &Segment{children: []*Segment{Child(spec.Name("x"))}},
+			branch: []*spec.Segment{spec.Child(spec.Name("y"))},
+			exp:    false,
+		},
+		{
+			name: "size",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")),
+				Child(spec.Name("y")),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Child(spec.Name("y")),
+			},
+			exp: false,
+		},
+		{
+			name: "eq_branch_mixed",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0), spec.Slice(1)).Append(
+						Child(spec.Wildcard).Append(
+							Child(mkFilter("$[?@]")),
+						),
+					),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Child(spec.Index(0), spec.Slice(1)),
+				spec.Child(spec.Wildcard),
+				spec.Child(mkFilter("$[?@]")),
+			},
+			exp: true,
+		},
+		{
+			name: "ne_child_selectors",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0), spec.Slice(1), spec.Name("x")).Append(
+						Child(spec.Wildcard).Append(
+							Child(mkFilter("$[?@]")),
+						),
+					),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Child(spec.Index(0), spec.Slice(1)),
+				spec.Child(spec.Wildcard),
+				spec.Child(mkFilter("$[?@]")),
+			},
+			exp: false,
+		},
+		{
+			name: "ne_spec_selectors",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0), spec.Slice(1)).Append(
+						Child(spec.Wildcard).Append(
+							Child(mkFilter("$[?@]")),
+						),
+					),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Child(spec.Index(0), spec.Slice(1), spec.Name("x")),
+				spec.Child(spec.Wildcard),
+				spec.Child(mkFilter("$[?@]")),
+			},
+			exp: false,
+		},
+		{
+			name: "diff_child_length",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("y")).Append(
+					Child(spec.Name("z")),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("y")),
+			},
+			exp: false,
+		},
+		{
+			name: "diff_spec_length",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("y")),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("y")),
+				spec.Child(spec.Name("z")),
+			},
+			exp: false,
+		},
+		{
+			name:   "ne_spec_desc",
+			seg:    &Segment{children: []*Segment{Child(spec.Name("x"))}},
+			branch: []*spec.Segment{spec.Descendant(spec.Name("x"))},
+			exp:    false,
+		},
+		{
+			name:   "ne_child_desc",
+			seg:    &Segment{children: []*Segment{Descendant(spec.Name("x"))}},
+			branch: []*spec.Segment{spec.Child(spec.Name("x"))},
+			exp:    false,
+		},
+		{
+			name: "ne_sub_spec_desc",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Name("y")),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Descendant(spec.Name("y")),
+			},
+			exp: false,
+		},
+		{
+			name: "ne_sub_child_desc",
+			seg: &Segment{children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Descendant(spec.Name("y")),
+				),
+			}},
+			branch: []*spec.Segment{
+				spec.Child(spec.Name("x")),
+				spec.Child(spec.Name("y")),
+			},
+			exp: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a.Equal(tc.exp, tc.seg.isBranch(tc.branch))
+		})
+	}
+}
+
+func TestMergeSelectors(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name      string
+		selectors []spec.Selector
+		merge     []spec.Selector
+		exp       []spec.Selector
+	}{
+		{
+			name: "none",
+		},
+		{
+			name:  "name_into_empty",
+			merge: []spec.Selector{spec.Name("x")},
+			exp:   []spec.Selector{spec.Name("x")},
+		},
+		{
+			name:      "name_into_existing",
+			selectors: []spec.Selector{spec.Name("x")},
+			merge:     []spec.Selector{spec.Name("x")},
+			exp:       []spec.Selector{spec.Name("x")},
+		},
+		{
+			name:      "name_into_index",
+			selectors: []spec.Selector{spec.Index(0)},
+			merge:     []spec.Selector{spec.Name("x")},
+			exp:       []spec.Selector{spec.Index(0), spec.Name("x")},
+		},
+		{
+			name:      "name_into_index_no_dupe",
+			selectors: []spec.Selector{spec.Index(0), spec.Name("x")},
+			merge:     []spec.Selector{spec.Name("x")},
+			exp:       []spec.Selector{spec.Index(0), spec.Name("x")},
+		},
+		{
+			name:      "index_slice",
+			selectors: []spec.Selector{spec.Slice(2), spec.Name("x")},
+			merge:     []spec.Selector{spec.Index(2), spec.Name("y")},
+			exp:       []spec.Selector{spec.Slice(2), spec.Name("x"), spec.Name("y")},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{selectors: tc.selectors}
+			seg.mergeSelectors(tc.merge)
+			a.Equal(tc.exp, seg.selectors)
+		})
+	}
+}
+
+func TestMergeChildren(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name     string
+		children []*Segment
+		expect   []*Segment
+	}{
+		{
+			name:     "empty",
+			children: []*Segment{},
+			expect:   []*Segment{},
+		},
+		{
+			name:     "one_child",
+			children: []*Segment{Child(spec.Name("x"))},
+			expect:   []*Segment{Child(spec.Name("x"))},
+		},
+		{
+			name:     "merge_name",
+			children: []*Segment{Child(spec.Name("x")), Child(spec.Name("x"))},
+			expect:   []*Segment{Child(spec.Name("x"))},
+		},
+		{
+			name:     "merge_selectors",
+			children: []*Segment{Child(spec.Name("x")), Child(spec.Name("y"))},
+			expect:   []*Segment{Child(spec.Name("x"), spec.Name("y"))},
+		},
+		{
+			name: "no_merge_diff_child",
+			children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Name("y")),
+				),
+				Child(spec.Name("a")).Append(
+					Child(spec.Name("z")),
+				),
+			},
+			expect: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Name("y")),
+				),
+				Child(spec.Name("a")).Append(
+					Child(spec.Name("z")),
+				),
+			},
+		},
+		{
+			name: "merge_same_child",
+			children: []*Segment{
+				Child(spec.Name("x")).Append(
+					Child(spec.Name("y")),
+				),
+				Child(spec.Name("a")).Append(
+					Child(spec.Name("y")),
+				),
+			},
+			expect: []*Segment{
+				Child(spec.Name("x"), spec.Name("a")).Append(
+					Child(spec.Name("y")),
+				),
+			},
+		},
+		{
+			name: "merge_same_nested_multi_select",
+			children: []*Segment{
+				Child(spec.Name("x"), spec.Name("y")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+					),
+				),
+				Child(spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+					),
+				),
+			},
+			expect: []*Segment{
+				Child(spec.Name("x"), spec.Name("y"), spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+					),
+				),
+			},
+		},
+		{
+			name: "no_merge_diff_depth",
+			children: []*Segment{
+				Child(spec.Name("x"), spec.Name("y")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")).Append(
+							Child(spec.Name("c")),
+						),
+					),
+				),
+				Child(spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+					),
+				),
+			},
+			expect: []*Segment{
+				Child(spec.Name("x"), spec.Name("y")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")).Append(
+							Child(spec.Name("c")),
+						),
+					),
+				),
+				Child(spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+					),
+				),
+			},
+		},
+		{
+			name: "merge_nested_selectors",
+			children: []*Segment{
+				Child(spec.Name("x"), spec.Name("y")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+						Child(spec.Name("c")),
+					),
+				),
+				Child(spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b")),
+						Child(spec.Name("c")),
+					),
+				),
+			},
+			expect: []*Segment{
+				Child(spec.Name("x"), spec.Name("y"), spec.Name("z")).Append(
+					Child(spec.Name("a")).Append(
+						Child(spec.Name("b"), spec.Name("c")),
+					),
+				),
+			},
+		},
+		{
+			name:     "merge_descendants",
+			children: []*Segment{Descendant(spec.Name("x")), Descendant(spec.Name("x"))},
+			expect:   []*Segment{Descendant(spec.Name("x"))},
+		},
+		{
+			name:     "merge_descendant_child",
+			children: []*Segment{Descendant(spec.Name("x")), Child(spec.Name("x"))},
+			expect:   []*Segment{Descendant(spec.Name("x"))},
+		},
+		{
+			name:     "merge_descendant_sub_child",
+			children: []*Segment{Descendant(spec.Name("x"), spec.Name("y")), Child(spec.Name("x"))},
+			expect:   []*Segment{Descendant(spec.Name("x"), spec.Name("y"))},
+		},
+		{
+			name:     "merge_child_descendant",
+			children: []*Segment{Child(spec.Name("x")), Descendant(spec.Name("x"))},
+			expect:   []*Segment{Descendant(spec.Name("x"))},
+		},
+		{
+			name:     "merge_child_sub_descendant",
+			children: []*Segment{Child(spec.Name("x")), Descendant(spec.Name("x"), spec.Name("y"))},
+			expect:   []*Segment{Descendant(spec.Name("x"), spec.Name("y"))},
+		},
+		{
+			name:     "merge_only_common_descendant_child_selector",
+			children: []*Segment{Descendant(spec.Name("x")), Child(spec.Name("x"), spec.Name("y"))},
+			expect:   []*Segment{Descendant(spec.Name("x")), Child(spec.Name("y"))},
+		},
+		{
+			name:     "merge_only_common_prev_descendant_selector",
+			children: []*Segment{Child(spec.Name("x"), spec.Name("y")), Descendant(spec.Name("x"))},
+			expect:   []*Segment{Child(spec.Name("y")), Descendant(spec.Name("x"))},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg := &Segment{children: tc.children}
+			seg.deduplicate()
+			a.Equal(tc.expect, seg.children)
+		})
+	}
+}
+
+func TestRemoveCommonSelectorsFrom(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		sel1 []spec.Selector
+		sel2 []spec.Selector
+		exp2 []spec.Selector
+		res  bool
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "empty_seg2",
+			sel1: []spec.Selector{spec.Name("x")},
+		},
+		{
+			name: "no_commonality",
+			sel1: []spec.Selector{spec.Name("x")},
+			sel2: []spec.Selector{spec.Name("y")},
+			exp2: []spec.Selector{spec.Name("y")},
+		},
+		{
+			name: "remove_one_all",
+			sel1: []spec.Selector{spec.Name("x")},
+			sel2: []spec.Selector{spec.Name("x")},
+			exp2: []spec.Selector{},
+			res:  true,
+		},
+		{
+			name: "remove_one",
+			sel1: []spec.Selector{spec.Name("x"), spec.Name("y")},
+			sel2: []spec.Selector{spec.Name("x")},
+			exp2: []spec.Selector{},
+			res:  true,
+		},
+		{
+			name: "remove_one_leave_one",
+			sel1: []spec.Selector{spec.Name("x"), spec.Name("y")},
+			sel2: []spec.Selector{spec.Name("x"), spec.Name("a")},
+			exp2: []spec.Selector{spec.Name("a")},
+			res:  false,
+		},
+		{
+			name: "remove_sub_slice",
+			sel1: []spec.Selector{spec.Slice(1, 3), spec.Name("y")},
+			sel2: []spec.Selector{spec.Name("x"), spec.Slice(1, 2)},
+			exp2: []spec.Selector{spec.Name("x")},
+			res:  false,
+		},
+		{
+			name: "remove_index_matching_slice",
+			sel1: []spec.Selector{spec.Slice(1, 3), spec.Name("y")},
+			sel2: []spec.Selector{spec.Name("x"), spec.Index(2)},
+			exp2: []spec.Selector{spec.Name("x")},
+			res:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seg1 := &Segment{selectors: tc.sel1}
+			seg2 := &Segment{selectors: tc.sel2}
+			a.Equal(tc.res, seg1.removeCommonSelectorsFrom(seg2))
+			a.Equal(tc.exp2, seg2.selectors, "selectors 2")
+		})
+	}
+}
+
+func TestSameBranches(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	simpleExists := mkFilter("$[?@]")
+	diffExists := mkFilter("$[?@.a]")
+
+	for _, tc := range []struct {
+		name string
+		seg1 *Segment
+		seg2 *Segment
+		exp  bool
+	}{
+		{
+			name: "empties",
+			seg1: Child(),
+			seg2: Child(),
+			exp:  true,
+		},
+		{
+			name: "single_child_eq_name",
+			seg1: Child().Append(Child(spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Name("x"))),
+			exp:  true,
+		},
+		{
+			name: "single_child_ne_name",
+			seg1: Child().Append(Child(spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Name("y"))),
+			exp:  false,
+		},
+		{
+			name: "single_child_eq_multi_select",
+			seg1: Child().Append(Child(spec.Name("x"), spec.Index(0))),
+			seg2: Child().Append(Child(spec.Name("x"), spec.Index(0))),
+			exp:  true,
+		},
+		{
+			name: "single_child_ne_multi_select",
+			seg1: Child().Append(Child(spec.Name("x"), spec.Index(0))),
+			seg2: Child().Append(Child(spec.Name("x"), spec.Index(1))),
+			exp:  false,
+		},
+		{
+			name: "single_child_ne_index_slice",
+			seg1: Child().Append(Child(spec.Name("x"), spec.Slice(0))),
+			seg2: Child().Append(Child(spec.Name("x"), spec.Index(1))),
+			exp:  false,
+		},
+		{
+			name: "single_child_ne_slices",
+			seg1: Child().Append(Child(spec.Name("x"), spec.Slice(0))),
+			seg2: Child().Append(Child(spec.Name("x"), spec.Slice(1))),
+			exp:  false,
+		},
+		{
+			name: "single_child_eq_filter",
+			seg1: Child().Append(Child(simpleExists)),
+			seg2: Child().Append(Child(simpleExists)),
+			exp:  true,
+		},
+		{
+			name: "single_child_ne_filter",
+			seg1: Child().Append(Child(simpleExists)),
+			seg2: Child().Append(Child(diffExists)),
+			exp:  false,
+		},
+		{
+			name: "wildcards",
+			seg1: Child().Append(Child(spec.Wildcard)),
+			seg2: Child().Append(Child(spec.Wildcard)),
+			exp:  true,
+		},
+		{
+			name: "wildcard_with_eq_name_is_ne",
+			seg1: Child().Append(Child(spec.Wildcard, spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Wildcard, spec.Name("x"))),
+			exp:  false,
+		},
+		{
+			name: "diff_branches_child_count",
+			seg1: Child().Append(Child(spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Name("x")), Child(spec.Name("x"))),
+			exp:  false,
+		},
+		{
+			name: "diff_children_child_count",
+			seg1: Child().Append(Child(spec.Name("x")), Child(spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Name("x"))),
+			exp:  false,
+		},
+		{
+			name: "same_children",
+			seg1: Child().Append(Child(spec.Name("x")), Child(spec.Name("x"))),
+			seg2: Child().Append(Child(spec.Name("x")), Child(spec.Name("x"))),
+			exp:  true,
+		},
+		{
+			name: "same_nested_children",
+			seg1: Child().Append(
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0)).Append(
+						Descendant(spec.Slice(4)),
+					),
+				),
+				Child(spec.Name("y")),
+			),
+			seg2: Child().Append(
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0)).Append(
+						Descendant(spec.Slice(4)),
+					),
+				),
+				Child(spec.Name("y")),
+			),
+			exp: true,
+		},
+		{
+			name: "diff_nested_children",
+			seg1: Child().Append(
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0)).Append(
+						Descendant(spec.Slice(4)),
+					),
+				),
+				Child(spec.Name("y")),
+			),
+			seg2: Child().Append(
+				Child(spec.Name("x")).Append(
+					Child(spec.Index(0)).Append(
+						Descendant(spec.Slice(3)),
+					),
+				),
+				Child(spec.Name("y")),
+			),
+			exp: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a.Equal(tc.exp, tc.seg1.sameBranches(tc.seg2))
+		})
+	}
+}
+
+func TestMergeSlices(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		seg  *Segment
+		exp  *Segment
+	}{
+		{
+			name: "Empty",
+			seg:  Child(),
+			exp:  Child(),
+		},
+		{
+			name: "no_slices",
+			seg:  Child(spec.Name("x"), spec.Index(0)),
+			exp:  Child(spec.Name("x"), spec.Index(0)),
+		},
+		{
+			name: "one_slice",
+			seg:  Child(spec.Name("x"), spec.Slice(12, 18)),
+			exp:  Child(spec.Name("x"), spec.Slice(12, 18)),
+		},
+		{
+			name: "sub_slice",
+			seg:  Child(spec.Name("x"), spec.Slice(10), spec.Slice(12, 18)),
+			exp:  Child(spec.Name("x"), spec.Slice(10)),
+		},
+		{
+			name: "slice_sub",
+			seg:  Child(spec.Name("x"), spec.Slice(12, 18), spec.Slice(10)),
+			exp:  Child(spec.Name("x"), spec.Slice(10)),
+		},
+		{
+			name: "sub_slice",
+			seg:  Child(spec.Name("x"), spec.Slice(8), spec.Slice(10), spec.Slice(12, 18)),
+			exp:  Child(spec.Name("x"), spec.Slice(8)),
+		},
+		{
+			name: "multi_slice_sub",
+			seg:  Child(spec.Name("x"), spec.Slice(12, 18), spec.Slice(8), spec.Slice(10)),
+			exp:  Child(spec.Name("x"), spec.Slice(8)),
+		},
+		{
+			name: "multi_overlaps",
+			seg:  Child(spec.Name("x"), spec.Slice(12, 18), spec.Slice(8), spec.Slice(2, 5), spec.Slice(4, 5)),
+			exp:  Child(spec.Name("x"), spec.Slice(8), spec.Slice(2, 5)),
+		},
+		{
+			name: "multi_overlap_reverse",
+			seg:  Child(spec.Name("x"), spec.Slice(4, 5), spec.Slice(2, 5), spec.Slice(8), spec.Slice(12, 18)),
+			exp:  Child(spec.Name("x"), spec.Slice(2, 5), spec.Slice(8)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.seg.mergeSlices()
+			a.Equal(tc.exp.selectors, tc.seg.selectors)
 		})
 	}
 }


### PR DESCRIPTION
Change `New` to accept a list of jsonpath.Path objects and teach it to merge them into a single tree structure, using the Segment struct defined here and relying on jsonpath.Selector for selectors. In order to create as efficient a query tree as possible, examine each segment and selector in all the paths and try to combine them, eliminate duplicates, and generally simplify things wherever possible.

General notes on how `New` works:

Make an effort to minimize the number of selectors in each segment of each path. Whereas `jsonpath.Select()` returns values for each selector that matches, even dupes, `jsontree.Select` does not, since it preserves the original data structure along the selected paths. So, for example, wildcards eliminate the need for any other selectors, indexes and slices that are encapsulated by other slices can be removed, and duplicates are removed, including filters (matching on stringification).

The comparisons are imperfect. For example, two filters can be logically equivalent but have different orders of operands, so would not be considered equivalent. This may be rectified in the future by normalizing filter stringification. Slice comparison is also sometimes impossible, mainly when using negative index arguments, since the values then become dependent on the length of input. These redundancies should be acceptable, however, as relatively less common and just mean some values would be selected twice. Their places in the resulting data structure are unchanged, however, so the outcome will be the same.

Trim trailing wildcard segments, since the result is the same as selecting the entirety of the parent segment.

Merge segments from different paths wherever their subsequent segments are identical, or when their selectors are equivalent. The exception is when one segment is a descendant segment (`..[]`) and the other is not. In that case, discard the non-descendant segment only when both are wildcards and constitute the same subpath.

Expand the selector and sub-path comparison logic in `segment.go`, including comparison and merging of selectors (eliminating duplicates and slice overlaps) and exact comparisons (ignoring slice overlaps). Switch from methods to functions to reduce duplication between equivalence vs. exact comparison and fill in a missing filter comparison.

Add `isBranch`, which compares a list of `jsonpath.Segments` to a `jsontree.Segment` and returns true when their paths are logically equivalent. This means that the `jsontree.Segment` must have only one sub-path with no additional branches.

Add `deduplicate` and run it after the paths have been merged, to make a second pass over the entire tree structure and eliminate further duplicates, notably segments with identical children, taking descendant vs regular child selectors into account, and then merging slice selectors.

Add tests for all of this functionality, covering all the paths in both `TestNew` and unit tests for all the functions.

Finally:

*   Update the example test to use jsonpath.Path objects.
*   Rename the `JSONTree` struct to `Tree`