### PR TITLE
Implement ordered mode

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -113,3 +113,52 @@ func ExampleTree_String() {
 	//     └── [0,2,1]
 	//         └── ["type","value"]
 }
+
+// Merge two path queries into an ordered mode JSONTree query. Note that the
+// second path selects the second item from the emails array, but the
+// [Tree.Select] returns it as the first item.
+func ExampleNew() {
+	value := map[string]any{
+		"name":  "Barrack Obama",
+		"years": "2009-2017",
+		"emails": []any{
+			"potus@example.com",
+			"barrack@example.net",
+		},
+	}
+
+	tree := jsontree.New(
+		jsonpath.MustParse("$.name"),
+		jsonpath.MustParse("$.emails[1]"),
+	)
+
+	// $.emails[1] appears at $emails[0].
+	fmt.Printf("%v\n", tree.Select(value))
+	// Output:
+	// map[emails:[barrack@example.net] name:Barrack Obama]
+}
+
+// Merge two path queries into a fixed mode JSONTree query. Note that the
+// second path selects the second item from the emails array and preserves its
+// index in the array returned by [Tree.Select] by offsetting the unselected
+// first item with nil.
+func ExampleNewFixedModeTree() {
+	value := map[string]any{
+		"name":  "Barrack Obama",
+		"years": "2009-2017",
+		"emails": []any{
+			"potus@example.com",
+			"barrack@example.net",
+		},
+	}
+
+	tree := jsontree.NewFixedModeTree(
+		jsonpath.MustParse("$.name"),
+		jsonpath.MustParse("$.emails[1]"),
+	)
+
+	// $.emails[1] remains at index 1, offset by nil.
+	fmt.Printf("%v\n", tree.Select(value))
+	// Output:
+	// map[emails:[<nil> barrack@example.net] name:Barrack Obama]
+}

--- a/segment_test.go
+++ b/segment_test.go
@@ -1448,10 +1448,12 @@ func TestRemoveCommonSelectorsFrom(t *testing.T) {
 	}{
 		{
 			name: "empty",
+			res:  true,
 		},
 		{
 			name: "empty_seg2",
 			sel1: []spec.Selector{spec.Name("x")},
+			res:  true,
 		},
 		{
 			name: "no_commonality",


### PR DESCRIPTION
This mode preserves the order, but not position of array values. It contrasts with the existing mode, now named "fixed mode", which preserves the index positions of array values. Add `NewFixedModeTree` to create a Tree in fixed mode, and change `New` to use ordered mode.

It works by factoring array index setting into a new method, `Tree.insert`, that replaces `nil` values with a `null` placeholder in ordered mode. Then, `Select` recursively compresses all selected arrays by removing `nil` values and replacing `null` placeholders with `nil`s. This ensures that `null` values selected by paths remain in the result.

It would be nice to find a way to enable this behavior without iterating over the entire selected value before returning it. An attempt to use a struct that automatically handled both append and index-preserving modes failed because arrays can be processed multiple times, but should not be appended multiple times. Thus the solution here, which attempts to minimize resource allocation at the expense of extra processing for every `Select`.

Add test expectations for ordered mode and test them alongside fixed mode. New tests also ensure that selected `nil`s are preserved in ordered mode while unselected `nil`s are not.

Document the two modes and how they differ, noting that ordered mode is the default. Add examples for each, and update the use cases documentation to reflect the application of each mode.

While at it:

*   Re-use the underlying array when deriving a new array from its values, and use `slices.Clip` to remove unused capacity from the new slice.
*   Take advantage of this change to simplify the logic of removeCommonSelectorsFrom`.