### PR TITLE
Refactor segment stringification

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -442,6 +442,7 @@ func (seg *segment) isWildcard() bool {
 // diagram.
 func (seg *segment) String() string {
 	buf := new(strings.Builder)
+	seg.writeSelectors(buf)
 	lastIndex := len(seg.children) - 1
 	for i, c := range seg.children {
 		c.writeTo(buf, "", i == lastIndex)
@@ -456,15 +457,8 @@ const (
 	blank = "    "
 )
 
-// writeTo writes the string representation of seg to buf.
-func (seg *segment) writeTo(buf *strings.Builder, prefix string, last bool) {
-	buf.WriteString(prefix)
-	if last {
-		buf.WriteString(elbow)
-	} else {
-		buf.WriteString(tee)
-	}
-
+// writeSelectors writes a string representation of seg.selectors to buf.
+func (seg *segment) writeSelectors(buf *strings.Builder) {
 	if seg.descendant {
 		buf.WriteString("..")
 	}
@@ -476,6 +470,17 @@ func (seg *segment) writeTo(buf *strings.Builder, prefix string, last bool) {
 		buf.WriteString(sel.String())
 	}
 	buf.WriteString("]\n")
+}
+
+// writeTo writes the string representation of seg to buf.
+func (seg *segment) writeTo(buf *strings.Builder, prefix string, last bool) {
+	buf.WriteString(prefix)
+	if last {
+		buf.WriteString(elbow)
+	} else {
+		buf.WriteString(tee)
+	}
+	seg.writeSelectors(buf)
 
 	lastIndex := len(seg.children) - 1
 	for i, sub := range seg.children {

--- a/tree.go
+++ b/tree.go
@@ -6,6 +6,7 @@ package jsontree
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/theory/jsonpath"
 	"github.com/theory/jsonpath/spec"
@@ -149,7 +150,13 @@ func newChild(cur *segment, seg *spec.Segment, selectors []spec.Selector) *segme
 // String returns a string representation of seg, starting from "$" for the
 // root, and including all of its child segments as a tree diagram.
 func (tree *Tree) String() string {
-	return "$\n" + tree.root.String()
+	buf := new(strings.Builder)
+	buf.WriteString("$\n")
+	lastIndex := len(tree.root.children) - 1
+	for i, c := range tree.root.children {
+		c.writeTo(buf, "", i == lastIndex)
+	}
+	return buf.String()
 }
 
 // Select selects tree's paths from the from JSON value into a new value. For


### PR DESCRIPTION
`segment.String()` was not including the selectors for the current segment in its output, only its children. This made debugging tricky.

So refactor segment stringification by adding `segment.writeSelectors` and teaching `segment.String` and `segment.WriteTo` to use it. This allows stringification of a selector to always include the selectors and children.

In other words, this code:

``` go
child(spec.Wildcard).Append(
    child(spec.Index(0), spec.Index(1))
).String()
```

Previously output:

```tree
[0, 1]
```

And now outputs this complete representation of the segment:

```
*
└── [0, 1]
```

This change requires that `Tree.String` now also iterate over children, so make that change, as well, and add explicit tests for `Tree.String`.